### PR TITLE
Update ToSqlVisitor.java

### DIFF
--- a/src/main/java/lambda2sql/ToSqlVisitor.java
+++ b/src/main/java/lambda2sql/ToSqlVisitor.java
@@ -37,6 +37,9 @@ public class ToSqlVisitor implements ExpressionVisitor<StringBuilder> {
 
 	@Override
 	public StringBuilder visit(ConstantExpression e) {
+		if (e.getValue() instanceof String) {
+			return sb.append("'").append(e.getValue().toString()).append("'");
+		}
 		return sb.append(e.getValue().toString());
 	}
 
@@ -54,7 +57,8 @@ public class ToSqlVisitor implements ExpressionVisitor<StringBuilder> {
 	@Override
 	public StringBuilder visit(MemberExpression e) {
 		String name = e.getMember().getName();
-		name = name.replaceAll("^(get|is)", "").toLowerCase();
+		name = name.replaceAll("^(get)", "")
+		name = name.substring(0, 1).toLowerCase() + name.substring(1);
 		return sb.append(name);
 	}
 


### PR DESCRIPTION
- Add SQL string quotation for strings. Otherwise the SQL query is not valid.
- Only make first letter of variable lowercase. `private String firstName;` will be called "firstName" on database, not "firstname".
- Only replace method names that start with "get". Boolean getters have the same name as the private variable. For example the getter for `private boolean isUnderAge;` would be `public boolean isUnderAge();` and not `public boolean getIsUnderAge();`.