### PR TITLE
Added support for variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.9
+targetCompatibility = 1.9
 
 version = '0.1'
 group = "ajermakovics"
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.trigersoft:jaque:2.0.4'
+    compile 'com.trigersoft:jaque:2.1.3'
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 

--- a/src/main/java/lambda2sql/Lambda2Sql.java
+++ b/src/main/java/lambda2sql/Lambda2Sql.java
@@ -1,44 +1,22 @@
 package lambda2sql;
 
-import static java.lang.System.getProperty;
-import static java.nio.file.Files.createTempDirectory;
-import static java.util.Objects.requireNonNull;
-
-import java.io.IOException;
-import java.util.function.Predicate;
-
 import com.trigersoft.jaque.expression.LambdaExpression;
+
+import java.util.function.Predicate;
 
 /**
  * A utility class for converting java lambdas to SQL.
- * It must be initializes with {@link #init()} before any lambdas are created.
  */
 public class Lambda2Sql {
 
-	private static final String DUMP_CLASSES_PROP = "jdk.internal.lambda.dumpProxyClasses";
-
 	/**
-	 * Initializes the jdk.internal.lambda.dumpProxyClasses system property with a temporary directory.
-	 * See https://bugs.openjdk.java.net/browse/JDK-8023524
-	 */
-	public static void init() {
-		try {
-			if( System.getProperty(DUMP_CLASSES_PROP) == null )
-				System.setProperty(DUMP_CLASSES_PROP, createTempDirectory("lambda").toString());
-		} catch (IOException e) {
-			throw new IllegalStateException(e);
-		}
-	}
-
-	/**
-	 * Converts a predicate lambda to SQL. Make sure to {@link Lamda2Sql#init()} before creating the predicate.<br/>
+	 * Converts a predicate lambda to SQL.
 	 * <pre>{@code person -> person.getAge() > 50 && person.isActive() }</pre>
 	 * Becomes a string:
 	 * <pre>{@code "age > 50 AND active" }</pre>
 	 * Supported operators: >,>=,<,<=,=,!=,&&,||,!
 	 */
-	public static <T> String toSql(Predicate<T> predicate) {
-		requireNonNull(getProperty(DUMP_CLASSES_PROP), "Call init() before creating the predicate.");
+	public static <T> String toSql(SqlPredicate<T> predicate) {
 		LambdaExpression<Predicate<T>> lambdaExpression = LambdaExpression.parse(predicate);
 		return lambdaExpression.accept(new ToSqlVisitor()).toString();
 	}

--- a/src/main/java/lambda2sql/SqlPredicate.java
+++ b/src/main/java/lambda2sql/SqlPredicate.java
@@ -1,0 +1,10 @@
+package lambda2sql;
+
+import java.io.Serializable;
+import java.util.function.Predicate;
+
+/**
+ * @author Collin Alpert
+ */
+public interface SqlPredicate<T> extends Predicate<T>, Serializable {
+}

--- a/src/test/java/lambda2sql/Lambda2SqlTest.java
+++ b/src/test/java/lambda2sql/Lambda2SqlTest.java
@@ -1,22 +1,12 @@
 package lambda2sql;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.function.Predicate;
-
-import org.junit.BeforeClass;
+import org.junit.Assert;
 import org.junit.Test;
-
 
 public class Lambda2SqlTest {
 
-	@BeforeClass
-	public static void init() throws Exception {
-		Lambda2Sql.init();
-	}
-
 	@Test
-	public void testComparisons() throws Exception {
+	public void testComparisons() {
 		assertEqual("age = 1", e -> e.getAge() == 1);
 		assertEqual("age > 1", e -> e.getAge() > 1);
 		assertEqual("age < 1", e -> e.getAge() < 1);
@@ -26,20 +16,26 @@ public class Lambda2SqlTest {
 	}
 
 	@Test
-	public void testLogicalOps() throws Exception {
-		assertEqual("!active", e -> ! e.isActive() );
-		assertEqual("age < 100 AND height > 200", e -> e.getAge() < 100 && e.getHeight() > 200 );
-		assertEqual("age < 100 OR height > 200", e -> e.getAge() < 100 || e.getHeight() > 200 );
+	public void testLogicalOps() {
+		assertEqual("!isActive", e -> !e.isActive());
+		assertEqual("age < 100 AND height > 200", e -> e.getAge() < 100 && e.getHeight() > 200);
+		assertEqual("age < 100 OR height > 200", e -> e.getAge() < 100 || e.getHeight() > 200);
 	}
 
 	@Test
-	public void testMultipleLogicalOps() throws Exception {
-		assertEqual("active AND (age < 100 OR height > 200)", e -> e.isActive() && (e.getAge() < 100 || e.getHeight() > 200) );
-		assertEqual("(age < 100 OR height > 200) AND active", e -> (e.getAge() < 100 || e.getHeight() > 200) && e.isActive() );
+	public void testMultipleLogicalOps() {
+		assertEqual("isActive AND (age < 100 OR height > 200)", e -> e.isActive() && (e.getAge() < 100 || e.getHeight() > 200));
+		assertEqual("(age < 100 OR height > 200) AND isActive", e -> (e.getAge() < 100 || e.getHeight() > 200) && e.isActive());
 	}
 
-	private void assertEqual(String expectedSql, Predicate<Person> p) {
+	@Test
+	public void testWithVariables() {
+		String name = "Donald";
+		assertEqual("name = 'Donald'", person -> person.getName() == name);
+	}
+
+	private void assertEqual(String expectedSql, SqlPredicate<Person> p) {
 		String sql = Lambda2Sql.toSql(p);
-		assertEquals(expectedSql, sql);
+		Assert.assertEquals(expectedSql, sql);
 	}
 }


### PR DESCRIPTION
Added tests for lambdas with variables. Also added serialized `Predicate<T>`, so there is no more need for the `init()` method. The `SqlPredicate<T>` can still be used as a lambda, just like you would use the `Predicate<T>`.